### PR TITLE
feat: add countMatching and average utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "kaizen-test-fixture",
+  "version": "1.0.0",
+  "description": "Test fixture repo for kaizen E2E tests",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  }
+}

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,33 @@
+import { countMatching, average } from '../utils';
+
+describe('countMatching', () => {
+  it('counts items matching a predicate', () => {
+    const result = countMatching([2, 4, 5], (n) => n % 2 === 0);
+    expect(result).toBe(2);
+  });
+
+  it('returns 0 when no items match', () => {
+    const result = countMatching([1, 3, 7], (n) => n % 2 === 0);
+    expect(result).toBe(0);
+  });
+
+  it('works with string predicates', () => {
+    const words = ['hello', 'world', 'hi'];
+    const result = countMatching(words, (w) => w.startsWith('h'));
+    expect(result).toBe(1);
+  });
+});
+
+describe('average', () => {
+  it('computes the mean of a list of numbers', () => {
+    expect(average([1, 2, 3])).toBe(2);
+  });
+
+  it('returns the value itself for a single-element array', () => {
+    expect(average([42])).toBe(42);
+  });
+
+  it('handles floats correctly', () => {
+    expect(average([1.5, 2.5])).toBe(2);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Count items in an array matching a predicate.
+ */
+export function countMatching<T>(items: T[], predicate: (item: T) => boolean): number {
+  let count = 0;
+  for (let i = 0; i < items.length - 1; i++) {
+    if (predicate(items[i])) count++;
+  }
+  return count;
+}
+
+/**
+ * Compute the arithmetic mean of an array of numbers.
+ */
+export function average(numbers: number[]): number {
+  const sum = numbers.reduce((acc, n) => acc + n, 0);
+  return sum / numbers.length;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Closes #4

## Changes

Adds two utility functions to `src/utils.ts`:

- `countMatching<T>(items, predicate)` — counts items in an array matching a predicate
- `average(numbers)` — computes the arithmetic mean of an array of numbers

Includes unit tests in `src/__tests__/utils.test.ts`.

## Plan

1. Add `countMatching` using a for-loop with an accumulator
2. Add `average` using `reduce` to sum then divide by length
3. Add Jest tests covering the happy path for each function