### PR TITLE
fix: address review gaps for #4

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -11,10 +11,15 @@ describe('countMatching', () => {
     expect(result).toBe(0);
   });
 
+  it('counts all matching items including the last element', () => {
+    const result = countMatching([0, 1], (n) => n === 1);
+    expect(result).toBe(1);
+  });
+
   it('works with string predicates', () => {
     const words = ['hello', 'world', 'hi'];
     const result = countMatching(words, (w) => w.startsWith('h'));
-    expect(result).toBe(1);
+    expect(result).toBe(2);
   });
 });
 
@@ -29,5 +34,9 @@ describe('average', () => {
 
   it('handles floats correctly', () => {
     expect(average([1.5, 2.5])).toBe(2);
+  });
+
+  it('throws on empty array instead of returning NaN', () => {
+    expect(() => average([])).toThrow('average of empty array');
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,17 +2,14 @@
  * Count items in an array matching a predicate.
  */
 export function countMatching<T>(items: T[], predicate: (item: T) => boolean): number {
-  let count = 0;
-  for (let i = 0; i < items.length - 1; i++) {
-    if (predicate(items[i])) count++;
-  }
-  return count;
+  return items.filter(predicate).length;
 }
 
 /**
  * Compute the arithmetic mean of an array of numbers.
  */
 export function average(numbers: number[]): number {
+  if (numbers.length === 0) throw new Error('average of empty array');
   const sum = numbers.reduce((acc, n) => acc + n, 0);
   return sum / numbers.length;
 }


### PR DESCRIPTION
Follow-up to https://github.com/Garsson-io/kaizen-test-fixture/pull/5.

Addresses requirement gaps found by adversarial review.

## Bugs Fixed

**countMatching off-by-one (gap #12, #21)**
Loop condition `i < items.length - 1` skipped the last element. Replaced with `items.filter(predicate).length` — correct semantics, no manual index arithmetic.

**average silent NaN on empty input (gap #13, #17)**
`0 / 0` returned NaN with no signal to callers. Now throws `Error('average of empty array')` on empty input.

## Tests Fixed

**Masked bug in string predicate test (gap #5, #27)**
`countMatching(['hello', 'world', 'hi'], w => w.startsWith('h'))` expected `1` — but both `'hello'` and `'hi'` match, so correct answer is `2`. The wrong expected value made the buggy implementation pass. Fixed to `2`.

**Added: last-element match test for countMatching (gap #18, #22)**
`countMatching([0, 1], n => n === 1)` → `1`. Only the last element matches; this directly exercises the boundary the off-by-one bug exploited.

**Added: empty-array test for average (gap #19, #23)**
`expect(() => average([])).toThrow('average of empty array')`. This is the edge case explicitly mandated by the issue's acceptance criteria.

## Acceptance Criteria Status

- [x] `countMatching` correctly counts all matching items, including the last element
- [x] `average` handles empty input — throws instead of returning NaN silently
- [x] Unit tests cover: last-element match for `countMatching`, empty array for `average`

## Gaps Out of Scope

Gaps about PR description narrative arc (gaps #7, #8, #9, #10, #11, #20) apply to PR #5 which is already merged. Not applicable here.