### PR TITLE
fix: correct off-by-one in countMatching (#7)

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -14,7 +14,13 @@ describe('countMatching', () => {
   it('works with string predicates', () => {
     const words = ['hello', 'world', 'hi'];
     const result = countMatching(words, (w) => w.startsWith('h'));
-    expect(result).toBe(1);
+    expect(result).toBe(2);
+  });
+
+  it('counts last element when it matches predicate', () => {
+    // Regression for off-by-one: loop used i < items.length - 1, skipping last element
+    const result = countMatching([2, 4, 6], (n) => n % 2 === 0);
+    expect(result).toBe(3);
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  */
 export function countMatching<T>(items: T[], predicate: (item: T) => boolean): number {
   let count = 0;
-  for (let i = 0; i < items.length - 1; i++) {
+  for (let i = 0; i < items.length; i++) {
     if (predicate(items[i])) count++;
   }
   return count;


### PR DESCRIPTION
## Summary

- `countMatching` used `i < items.length - 1`, skipping the last element on every call
- Fixed loop condition to `i < items.length`
- Fixed the existing string-predicate test that was masking the bug (expected 1 match in `['hello', 'world', 'hi']` — correct answer is 2)
- Added regression test: `countMatching([2, 4, 6], n => n % 2 === 0)` must return 3

## Test plan

- [x] Existing tests updated to reflect correct behavior
- [x] Regression test added that would have caught the off-by-one
- [x] All 7 tests pass

Run tag: fixture-bugs-20260326-0134/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)