### PR TITLE
fix: guard average() against empty array (#8)

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -30,4 +30,9 @@ describe('average', () => {
   it('handles floats correctly', () => {
     expect(average([1.5, 2.5])).toBe(2);
   });
+
+  it('throws on empty array instead of returning NaN', () => {
+    // Regression for silent NaN: average([]) divided by zero, returning NaN
+    expect(() => average([])).toThrow('average requires at least one number');
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,7 @@ export function countMatching<T>(items: T[], predicate: (item: T) => boolean): n
  * Compute the arithmetic mean of an array of numbers.
  */
 export function average(numbers: number[]): number {
+  if (numbers.length === 0) throw new Error('average requires at least one number');
   const sum = numbers.reduce((acc, n) => acc + n, 0);
   return sum / numbers.length;
 }


### PR DESCRIPTION
## Summary

- `average([])` silently returned `NaN` (sum=0 divided by length=0)
- Added guard: throws `'average requires at least one number'` when input is empty
- Added regression test that would have caught the silent NaN

## Test plan

- [x] Regression test: `expect(() => average([])).toThrow(...)` — now passes
- [x] All 7 existing tests still pass

Run tag: fixture-bugs-20260326-0134/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)