### PR TITLE
fix: off-by-one in countMatching and NaN on empty in average

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -14,7 +14,12 @@ describe('countMatching', () => {
   it('works with string predicates', () => {
     const words = ['hello', 'world', 'hi'];
     const result = countMatching(words, (w) => w.startsWith('h'));
-    expect(result).toBe(1);
+    expect(result).toBe(2);
+  });
+
+  it('counts the last element when it matches', () => {
+    const result = countMatching([1, 2, 4], (n) => n % 2 === 0);
+    expect(result).toBe(2);
   });
 });
 
@@ -29,5 +34,9 @@ describe('average', () => {
 
   it('handles floats correctly', () => {
     expect(average([1.5, 2.5])).toBe(2);
+  });
+
+  it('returns 0 for an empty array', () => {
+    expect(average([])).toBe(0);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  */
 export function countMatching<T>(items: T[], predicate: (item: T) => boolean): number {
   let count = 0;
-  for (let i = 0; i < items.length - 1; i++) {
+  for (let i = 0; i < items.length; i++) {
     if (predicate(items[i])) count++;
   }
   return count;
@@ -13,6 +13,7 @@ export function countMatching<T>(items: T[], predicate: (item: T) => boolean): n
  * Compute the arithmetic mean of an array of numbers.
  */
 export function average(numbers: number[]): number {
+  if (numbers.length === 0) return 0;
   const sum = numbers.reduce((acc, n) => acc + n, 0);
   return sum / numbers.length;
 }


### PR DESCRIPTION
## Summary

- **Issue #11** — `countMatching`: loop used `i < items.length - 1`, silently skipping the last element. Fixed to `i < items.length`.
- **Issue #12** — `average`: returned `NaN` for empty arrays (0/0). Added early return of `0` when input is empty.
- Corrected existing `works with string predicates` test whose expected value was based on the buggy skip-last-element behavior (both 'hello' and 'hi' start with 'h', correct count is 2).
- Added regression tests: last-element match for `countMatching`, empty array for `average`.

## Test plan

- [x] All 8 tests pass (`npm test`)
- [x] `countMatching` now includes the last element
- [x] `average([])` returns `0` instead of `NaN`

Run tag: autodent-e2e-1774482712396/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)