### PR TITLE
fix: correct off-by-one in countMatching and NaN-on-empty in average

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -14,7 +14,18 @@ describe('countMatching', () => {
   it('works with string predicates', () => {
     const words = ['hello', 'world', 'hi'];
     const result = countMatching(words, (w) => w.startsWith('h'));
-    expect(result).toBe(1);
+    expect(result).toBe(2);
+  });
+
+  it('counts all matching elements including the last one', () => {
+    // INVARIANT: countMatching must count every element in the array,
+    // including the last one — no off-by-one skipping.
+    const result = countMatching([2, 4, 6], (n) => n % 2 === 0);
+    expect(result).toBe(3);
+  });
+
+  it('returns 0 for an empty array', () => {
+    expect(countMatching([], () => true)).toBe(0);
   });
 });
 
@@ -29,5 +40,10 @@ describe('average', () => {
 
   it('handles floats correctly', () => {
     expect(average([1.5, 2.5])).toBe(2);
+  });
+
+  it('throws for an empty array', () => {
+    // INVARIANT: average of an empty array is undefined — must throw, not return NaN.
+    expect(() => average([])).toThrow("Cannot compute average of empty array");
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  */
 export function countMatching<T>(items: T[], predicate: (item: T) => boolean): number {
   let count = 0;
-  for (let i = 0; i < items.length - 1; i++) {
+  for (let i = 0; i < items.length; i++) {
     if (predicate(items[i])) count++;
   }
   return count;
@@ -13,6 +13,9 @@ export function countMatching<T>(items: T[], predicate: (item: T) => boolean): n
  * Compute the arithmetic mean of an array of numbers.
  */
 export function average(numbers: number[]): number {
+  if (numbers.length === 0) {
+    throw new Error("Cannot compute average of empty array");
+  }
   const sum = numbers.reduce((acc, n) => acc + n, 0);
   return sum / numbers.length;
 }


### PR DESCRIPTION
## Summary

- **Issue #14** — `countMatching` loop was `i < items.length - 1`, skipping the last element. Fixed to `i < items.length`.
- **Issue #15** — `average` returned `NaN` for empty input (divide by zero). Now throws `Error("Cannot compute average of empty array")`.
- Updated a bug-affirming test (string predicates expected `1` because of the off-by-one) to expect the correct value `2`.
- Added invariant regression tests: `countMatching([2,4,6], n=>n%2===0)` returns `3`; `average([])` throws.

## Test plan

- [x] All 9 tests pass (`npm test`)
- [x] New regression test for off-by-one covers last element
- [x] New regression test for empty average asserts throw with correct message

Run tag: autodent-e2e-1774483501026/run-1

Closes #14
Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)