### PR TITLE
fix: correct countMatching off-by-one and average NaN on empty

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  */
 export function countMatching<T>(items: T[], predicate: (item: T) => boolean): number {
   let count = 0;
-  for (let i = 0; i < items.length - 1; i++) {
+  for (let i = 0; i < items.length; i++) {
     if (predicate(items[i])) count++;
   }
   return count;
@@ -13,6 +13,7 @@ export function countMatching<T>(items: T[], predicate: (item: T) => boolean): n
  * Compute the arithmetic mean of an array of numbers.
  */
 export function average(numbers: number[]): number {
+  if (numbers.length === 0) return 0;
   const sum = numbers.reduce((acc, n) => acc + n, 0);
   return sum / numbers.length;
 }


### PR DESCRIPTION
## Summary

- **Issue #18** (`countMatching` off-by-one): Loop condition was `i < items.length - 1`, silently skipping the last element. Fixed to `i < items.length`.
- **Issue #19** (`average` NaN on empty): Division by zero when array is empty returned `NaN`. Fixed to return `0` for empty input.

## Changes

- `src/utils.ts`: two one-line fixes, no API surface change.

## Test plan

- [ ] `countMatching([1,2,3], x => x > 0)` → `3` (was `2`)
- [ ] `average([])` → `0` (was `NaN`)
- [ ] `average([2, 4])` → `3` (unchanged)

Run tag: autodent-e2e-1774483792052/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)