### PR TITLE
fix: correct off-by-one in countMatching and NaN on empty in average

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@
  */
 export function countMatching<T>(items: T[], predicate: (item: T) => boolean): number {
   let count = 0;
-  for (let i = 0; i < items.length - 1; i++) {
+  for (let i = 0; i < items.length; i++) {
     if (predicate(items[i])) count++;
   }
   return count;
@@ -13,6 +13,7 @@ export function countMatching<T>(items: T[], predicate: (item: T) => boolean): n
  * Compute the arithmetic mean of an array of numbers.
  */
 export function average(numbers: number[]): number {
+  if (numbers.length === 0) return 0;
   const sum = numbers.reduce((acc, n) => acc + n, 0);
   return sum / numbers.length;
 }


### PR DESCRIPTION
## Summary

- **Issue #21**: `countMatching` loop used `i < items.length - 1`, skipping the last element. Fixed to `i < items.length`.
- **Issue #22**: `average` returned `NaN` when called with an empty array (`0/0`). Fixed by returning `0` for empty input.

Both bugs were in `src/utils.ts`.

## Test plan
- [ ] `countMatching([1,2,3], x => x > 0)` returns `3` (not `2`)
- [ ] `average([])` returns `0` (not `NaN`)
- [ ] `average([2, 4])` still returns `3`

Run tag: autodent-e2e-1774483998687/run-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)